### PR TITLE
Add admin column to users model.

### DIFF
--- a/db/migrate/20200507223242_add_admin_boolean_to_users.rb
+++ b/db/migrate/20200507223242_add_admin_boolean_to_users.rb
@@ -1,0 +1,5 @@
+class AddAdminBooleanToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :admin, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_07_172819) do
+ActiveRecord::Schema.define(version: 2020_05_07_223242) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -72,6 +72,7 @@ ActiveRecord::Schema.define(version: 2020_05_07_172819) do
     t.datetime "updated_at", precision: 6, null: false
     t.string "authentication_token", limit: 30
     t.integer "last_q"
+    t.boolean "admin", default: false
     t.index ["authentication_token"], name: "index_users_on_authentication_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true


### PR DESCRIPTION
Added a new column to the Users model: admin with a boolean datatype set to default false. 

