### PR TITLE
Add user last_q, last_l to default 0

### DIFF
--- a/db/migrate/20200514173707_add_defaults_to_users.rb
+++ b/db/migrate/20200514173707_add_defaults_to_users.rb
@@ -1,0 +1,6 @@
+class AddDefaultsToUsers < ActiveRecord::Migration[6.0]
+  def change
+    change_column :users, :last_q, :integer, default: 0
+    change_column :users, :last_l, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_13_174603) do
+ActiveRecord::Schema.define(version: 2020_05_14_173707) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -74,9 +74,9 @@ ActiveRecord::Schema.define(version: 2020_05_13_174603) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "authentication_token", limit: 30
-    t.integer "last_q"
+    t.integer "last_q", default: 0
     t.boolean "admin", default: false
-    t.integer "last_l"
+    t.integer "last_l", default: 0
     t.index ["authentication_token"], name: "index_users_on_authentication_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true


### PR DESCRIPTION
Changed Users model schema to default to 0 on the following columns upon creation of a new user. 
- last_q
- last_l